### PR TITLE
Add AdminDashboard controller for admin specific features

### DIFF
--- a/src/main/java/com/revature/revworkforce/controller/AdminDashboardController.java
+++ b/src/main/java/com/revature/revworkforce/controller/AdminDashboardController.java
@@ -1,0 +1,58 @@
+package com.revature.revworkforce.controller;
+
+import com.revature.revworkforce.enums.EmployeeStatus;
+import com.revature.revworkforce.model.Employee;
+import com.revature.revworkforce.repository.EmployeeRepository;
+import com.revature.revworkforce.security.SecurityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Admin Dashboard Controller.
+ * 
+ * Handles admin-specific dashboard and operations.
+ * Only accessible by users with ADMIN role.
+ * 
+ * @author RevWorkForce Team
+ */
+@Controller
+@RequestMapping("/admin")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminDashboardController {
+    
+    @Autowired
+    private EmployeeRepository employeeRepository;
+    
+    /**
+     * Display admin dashboard.
+     * 
+     * @param model the model
+     * @return admin dashboard view
+     */
+    @GetMapping("/dashboard")
+    public String adminDashboard(Model model) {
+        String employeeId = SecurityUtils.getCurrentUsername();
+        
+        // Get current user
+        Employee currentUser = employeeRepository.findById(employeeId).orElse(null);
+        
+        if (currentUser != null) {
+            model.addAttribute("currentUser", currentUser);
+            model.addAttribute("fullName", currentUser.getFullName());
+        }
+        
+        // Get statistics
+        long totalEmployees = employeeRepository.count();
+        long activeEmployees = employeeRepository.countByStatus(EmployeeStatus.ACTIVE);
+        
+        model.addAttribute("totalEmployees", totalEmployees);
+        model.addAttribute("activeEmployees", activeEmployees);
+        model.addAttribute("pageTitle", "Admin Dashboard");
+        
+        return "admin/dashboard";
+    }
+}


### PR DESCRIPTION
- issue #124

This PR introduces the `AdminDashboardController`, which handles **admin-only dashboard operations**:

* Displays current admin info
* Shows total and active employee statistics
* Restricts access to ADMIN users using Spring Security

```text
controller/AdminDashboardController.java
```



### Role-Based Access

* Secured with `@PreAuthorize("hasRole('ADMIN')")`
* Ensures only ADMIN users can access `/admin/**` endpoints

### Current Admin Info

* Fetches logged-in admin’s info using `SecurityUtils`
* Adds attributes to model for personalized dashboard view

### Employee Statistics

* Total employees
* Active employees
* Data added to the model for display in the dashboard






## Walkthrough

1. Login as an ADMIN → visit `/admin/dashboard` → dashboard loads correctly
2. Login as a non-ADMIN → try `/admin/dashboard` → should **deny access**
3. Verify model attributes:
   * `currentUser` → admin info
   * `fullName` → admin’s name
   * `totalEmployees` → correct count
   * `activeEmployees` → correct count
4. Ensure `pageTitle` is set correctly


##  Related

* Works with `DashboardController` and `SecurityUtils`
