### PR TITLE
Add Role-Specific Dashboard Controllers for Manager and Employee

### DIFF
--- a/src/main/java/com/revature/revworkforce/controller/EmployeeDashboardController.java
+++ b/src/main/java/com/revature/revworkforce/controller/EmployeeDashboardController.java
@@ -1,0 +1,55 @@
+package com.revature.revworkforce.controller;
+
+import com.revature.revworkforce.model.Employee;
+import com.revature.revworkforce.repository.EmployeeRepository;
+import com.revature.revworkforce.security.SecurityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Employee Dashboard Controller.
+ * 
+ * Handles employee self-service dashboard and operations.
+ * Accessible by all authenticated users.
+ * 
+ * @author RevWorkForce Team
+ */
+@Controller
+@RequestMapping("/employee")
+@PreAuthorize("hasAnyRole('EMPLOYEE', 'MANAGER', 'ADMIN')")
+public class EmployeeDashboardController {
+    
+    @Autowired
+    private EmployeeRepository employeeRepository;
+    
+    /**
+     * Display employee dashboard.
+     * 
+     * @param model the model
+     * @return employee dashboard view
+     */
+    @GetMapping("/dashboard")
+    public String employeeDashboard(Model model) {
+        String employeeId = SecurityUtils.getCurrentUsername();
+        
+        // Get current user
+        Employee currentUser = employeeRepository.findById(employeeId).orElse(null);
+        
+        if (currentUser != null) {
+            model.addAttribute("currentUser", currentUser);
+            model.addAttribute("fullName", currentUser.getFullName());
+            model.addAttribute("designation", currentUser.getDesignation() != null ? 
+                              currentUser.getDesignation().getDesignationName() : "N/A");
+            model.addAttribute("department", currentUser.getDepartment() != null ? 
+                              currentUser.getDepartment().getDepartmentName() : "N/A");
+        }
+        
+        model.addAttribute("pageTitle", "Employee Dashboard");
+        
+        return "employee/dashboard";
+    }
+}

--- a/src/main/java/com/revature/revworkforce/controller/ManagerDashboardController.java
+++ b/src/main/java/com/revature/revworkforce/controller/ManagerDashboardController.java
@@ -1,0 +1,57 @@
+package com.revature.revworkforce.controller;
+
+import com.revature.revworkforce.model.Employee;
+import com.revature.revworkforce.repository.EmployeeRepository;
+import com.revature.revworkforce.security.SecurityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+/**
+ * Manager Dashboard Controller.
+ * 
+ * Handles manager-specific dashboard and operations.
+ * Accessible by users with MANAGER or ADMIN role.
+ * 
+ * @author RevWorkForce Team
+ */
+@Controller
+@RequestMapping("/manager")
+@PreAuthorize("hasAnyRole('MANAGER', 'ADMIN')")
+public class ManagerDashboardController {
+    
+    @Autowired
+    private EmployeeRepository employeeRepository;
+    
+    /**
+     * Display manager dashboard.
+     * 
+     * @param model the model
+     * @return manager dashboard view
+     */
+    @GetMapping("/dashboard")
+    public String managerDashboard(Model model) {
+        String employeeId = SecurityUtils.getCurrentUsername();
+        
+        // Get current user
+        Employee currentUser = employeeRepository.findById(employeeId).orElse(null);
+        
+        if (currentUser != null) {
+            model.addAttribute("currentUser", currentUser);
+            model.addAttribute("fullName", currentUser.getFullName());
+            
+            // Get team members (employees reporting to this manager)
+            List<Employee> teamMembers = employeeRepository.findByManager_EmployeeId(employeeId);
+            model.addAttribute("teamSize", teamMembers.size());
+        }
+        
+        model.addAttribute("pageTitle", "Manager Dashboard");
+        
+        return "manager/dashboard";
+    }
+}


### PR DESCRIPTION

- issue #124 

This PR introduces two new dashboard controllers for **role-specific dashboards**:

1. **ManagerDashboardController** – displays manager info and team statistics.
2. **EmployeeDashboardController** – displays employee self-service information.

```text
controller/ManagerDashboardController.java
controller/EmployeeDashboardController.java
```

### Manager Dashboard

* Access restricted to MANAGER and ADMIN.
* Displays:
  * Current manager info
  * Team size (# of employees reporting to this manager)
* Page title set dynamically: `Manager Dashboard`.

### Employee Dashboard
* Access restricted to EMPLOYEE, MANAGER, ADMIN.
* Displays:
  * Current employee info
  * Designation (with null-safe handling)
  * Department (with null-safe handling)
* Page title set dynamically: `Employee Dashboard`.



## Walkthrough

1. **Manager Login** → `/manager/dashboard` → team size and personal info visible.
2. **Employee Login** → `/employee/dashboard` → personal info, designation, and department visible.
3. **Unauthorized access** → e.g., EMPLOYEE visiting `/manager/dashboard` → access denied.
4. Verify `pageTitle` and model attributes are correctly populated.


## Related 

* Integrates with `DashboardController`, `SecurityUtils`, and `EmployeeRepository`.
