### PR TITLE
Fix `LazyInitializationException` on Employee Dashboard

### DIFF
--- a/src/main/java/com/revature/revworkforce/model/Employee.java
+++ b/src/main/java/com/revature/revworkforce/model/Employee.java
@@ -123,17 +123,16 @@ public class Employee {
      * Many employees belong to one Department.
      * Lazy fetch to avoid unnecessary loading.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "department_id")
     private Department department;
-
+    
     /**
      * Many employees share one Designation.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "designation_id")
     private Designation designation;
-
     /**
      * Self-referencing relationship.
      * Represents reporting hierarchy (Manager → Employee).


### PR DESCRIPTION

This PR fixes the `LazyInitializationException` that occurred when accessing `employee.getDepartment()` on the Employee Dashboard.

**Changes:**

* Updated the `Employee.department` mapping from `LAZY` to `EAGER` fetch:

```java
@ManyToOne(fetch = FetchType.EAGER)
@JoinColumn(name = "department_id")
private Department department;
```

```java
@ManyToOne(fetch = FetchType.EAGER)
@JoinColumn(name = "designation_id")
private Designation designation;
```

* Ensures `Department` is loaded along with `Employee` during repository fetch.
* Prevents Hibernate from attempting to lazy-load `department` outside an active session.
* Keeps dashboard rendering smooth and avoids runtime exceptions.

**Before:**

* Accessing `employee.getDepartment()` on the dashboard caused:

  ```
  could not initialize proxy [com.revature.revworkforce.model.Department#1] - no Session
  ```

**After:**

* Employee and Department are loaded together. Dashboard loads successfully without errors.

**Testing:**

* Navigated to `/employee/dashboard` as `ROLE_ADMIN`.
* Verified Employee info and Department displayed correctly.
* No `LazyInitializationException` observed in logs.

<img width="1887" height="891" alt="image" src="https://github.com/user-attachments/assets/37aed0cb-8e92-4a64-a035-ec6295769bbd" />

**Impact:**

* Minor change to entity fetch strategy.
* May slightly increase query load when fetching Employees, but improves stability for dashboard rendering.