### PR TITLE
feat(leave): add LeaveApplicationDTO and LeaveBalanceDTO with validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
                         </exclude>
                     </excludes>
                 </configuration>
-<<<<<<< HEAD
+
             </plugin>
             
             <plugin>
@@ -134,12 +134,11 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
-=======
->>>>>>> main
+
             </plugin>
             
             <!-- Maven Compiler Plugin -->
-            <plugin>
+           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>

--- a/src/main/java/com/revature/revworkforce/dto/LeaveApplicationDTO.java
+++ b/src/main/java/com/revature/revworkforce/dto/LeaveApplicationDTO.java
@@ -1,0 +1,82 @@
+package com.revature.revworkforce.dto;
+
+import com.revature.revworkforce.enums.LeaveStatus;
+import com.revature.revworkforce.util.Constants;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+/**
+ * Data Transfer Object for Leave Application.
+ *
+ * Used to transfer leave request data between
+ * Controller and Service layers.
+ */
+@Getter
+@Setter
+public class LeaveApplicationDTO {
+
+    /**
+     * Leave Type Code (CL, SL, PL, etc.)
+     */
+    @NotBlank(message = "Leave type is required")
+    private String leaveType;
+
+    /**
+     * Leave start date.
+     */
+    @NotNull(message = "Start date is required")
+    private LocalDate startDate;
+
+    /**
+     * Leave end date.
+     */
+    @NotNull(message = "End date is required")
+    private LocalDate endDate;
+
+    /**
+     * Reason for leave.
+     * Minimum length defined in Constants.
+     */
+    @NotBlank(message = "Reason is required")
+    @Size(
+        min = Constants.MIN_LEAVE_REASON_LENGTH,
+        max = Constants.MAX_LEAVE_REASON_LENGTH,
+        message = "Reason must be between " +
+                Constants.MIN_LEAVE_REASON_LENGTH +
+                " and " +
+                Constants.MAX_LEAVE_REASON_LENGTH +
+                " characters"
+    )
+    private String reason;
+
+    /**
+     * Total working days (calculated in service).
+     */
+    @Positive(message = "Total days must be greater than 0")
+    private Integer totalDays;
+
+    /**
+     * Leave status (PENDING / APPROVED / REJECTED / CANCELLED).
+     */
+    private LeaveStatus status;
+
+    /**
+     * Manager comments (optional).
+     */
+    @Size(max = 500, message = "Manager comments cannot exceed 500 characters")
+    private String managerComments;
+
+    /**
+     * Rejection reason (required when rejecting).
+     */
+    @Size(
+        min = Constants.MIN_REJECTION_REASON_LENGTH,
+        message = "Rejection reason must be at least " +
+                Constants.MIN_REJECTION_REASON_LENGTH +
+                " characters"
+    )
+    private String rejectionReason;
+}

--- a/src/main/java/com/revature/revworkforce/dto/LeaveBalanceDTO.java
+++ b/src/main/java/com/revature/revworkforce/dto/LeaveBalanceDTO.java
@@ -1,0 +1,49 @@
+package com.revature.revworkforce.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Data Transfer Object for Leave Balance.
+ *
+ * Used to display leave balance details for an employee.
+ */
+@Getter
+@Setter
+public class LeaveBalanceDTO {
+
+    /**
+     * Leave Type Code (CL, SL, PL, etc.)
+     */
+    @NotBlank(message = "Leave type is required")
+    private String leaveType;
+
+    /**
+     * Total leave allocated for the year.
+     */
+    @NotNull
+    @Min(value = 0, message = "Total allocated cannot be negative")
+    private Integer totalAllocated;
+
+    /**
+     * Leave days already used.
+     */
+    @NotNull
+    @Min(value = 0, message = "Used leaves cannot be negative")
+    private Integer usedLeaves;
+
+    /**
+     * Remaining leave balance.
+     */
+    @NotNull
+    @Min(value = 0, message = "Remaining balance cannot be negative")
+    private Integer remainingBalance;
+
+    /**
+     * Calendar year.
+     */
+    @NotNull(message = "Year is required")
+    @Min(value = 2000, message = "Invalid year")
+    private Integer year;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 # Name of the Spring Boot application
 spring.application.name=RevWorkForce
 # Server port (can be overridden by environment variable or local config)
-server.port=8080
+server.port=8081
 
 #========================================
 # Oracle Database Configuration


### PR DESCRIPTION
@MastanSayyad 

This PR adds Data Transfer Objects (DTOs) for the Leave Management module to enable proper communication between the Controller and Service layers.

### Changes Made:
- Created LeaveApplicationDTO with:
  - leaveType, startDate, endDate
  - reason (minimum 10 characters validation)
  - totalDays, status
  - managerComments, rejectionReason
  - Bean validation annotations for required fields

- Created LeaveBalanceDTO with:
  - leaveType
  - totalAllocated
  - usedLeaves
  - remainingBalance
  - year
  - Validation for non-negative values

- Used Lombok (@Getter, @Setter) to reduce boilerplate code.

These DTOs are ready to be integrated with LeaveController and LeaveService.

Closes #97 