### PR TITLE
feat(rbac): configure role-based access control for leave module endp…

### DIFF
--- a/src/main/java/com/revature/revworkforce/controller/LeaveController.java
+++ b/src/main/java/com/revature/revworkforce/controller/LeaveController.java
@@ -21,7 +21,7 @@ public class LeaveController {
     // ================= EMPLOYEE =================
 
     @GetMapping("/employee/apply")
-    @PreAuthorize("hasAnyRole('EMPLOYEE')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','MANAGER','ADMIN')")
     public String showApplyPage(Model model, Authentication auth) {
 
         String employeeId = auth.getName();
@@ -35,7 +35,7 @@ public class LeaveController {
     }
 
     @PostMapping("/employee/apply")
-    @PreAuthorize("hasAnyRole('EMPLOYEE')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','MANAGER','ADMIN')")
     public String applyLeave(@ModelAttribute LeaveApplicationDTO dto,
                              Authentication auth) {
 
@@ -44,7 +44,7 @@ public class LeaveController {
     }
 
     @GetMapping("/employee/history")
-    @PreAuthorize("hasAnyRole('EMPLOYEE')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','MANAGER','ADMIN')")
     public String showHistory(Model model, Authentication auth) {
 
         model.addAttribute("history",
@@ -54,7 +54,7 @@ public class LeaveController {
     }
 
     @PostMapping("/employee/cancel/{id}")
-    @PreAuthorize("hasAnyRole('EMPLOYEE')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','MANAGER','ADMIN')")
     public String cancel(@PathVariable Long id, Authentication auth) {
 
         leaveService.cancelLeave(id, auth.getName());
@@ -62,7 +62,7 @@ public class LeaveController {
     }
 
     @GetMapping("/employee/balance")
-    @PreAuthorize("hasAnyRole('EMPLOYEE')")
+    @PreAuthorize("hasAnyRole('EMPLOYEE','MANAGER','ADMIN')")
     public String showBalance(Model model,
                               Authentication auth,
                               @RequestParam(required = false) Integer year) {

--- a/src/main/java/com/revature/revworkforce/controller/LeaveController.java
+++ b/src/main/java/com/revature/revworkforce/controller/LeaveController.java
@@ -78,12 +78,12 @@ public class LeaveController {
 
         return "employee/leave/balance";
     }
-    // ================= MANAGER =================
+   
 
  // ================= MANAGER =================
 
     @GetMapping("/manager/pending")
-    @PreAuthorize("hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER','ADMIN')")
     public String showPendingLeaves(Model model, Authentication auth) {
 
         String managerId = auth.getName();
@@ -96,7 +96,7 @@ public class LeaveController {
 
    
     @GetMapping("/manager/team")
-    @PreAuthorize("hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER','ADMIN')")
     public String showTeamLeaves(Model model, Authentication auth) {
 
         String managerId = auth.getName();
@@ -109,7 +109,7 @@ public class LeaveController {
     
 
     @GetMapping("/manager/review/{id}")
-    @PreAuthorize("hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER','ADMIN')")
     public String reviewLeave(@PathVariable Long id,
                               Model model,
                               Authentication auth) {
@@ -121,7 +121,7 @@ public class LeaveController {
     }
 
     @PostMapping("/manager/approve/{id}")
-    @PreAuthorize("hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER','ADMIN')")
     public String approve(@PathVariable Long id,
                           @RequestParam(required = false) String comments,
                           Authentication authentication) {
@@ -134,7 +134,7 @@ public class LeaveController {
     }
 
     @PostMapping("/manager/reject/{id}")
-    @PreAuthorize("hasRole('MANAGER')")
+    @PreAuthorize("hasAnyRole('MANAGER','ADMIN')")
     public String reject(@PathVariable Long id,
                          @RequestParam String rejectionReason,
                          Authentication authentication) {

--- a/src/main/java/com/revature/revworkforce/service/impl/LeaveServiceImpl.java
+++ b/src/main/java/com/revature/revworkforce/service/impl/LeaveServiceImpl.java
@@ -126,11 +126,9 @@ public class LeaveServiceImpl implements LeaveService {
     // =========================================================
     // APPROVE
     // =========================================================
-
     @Override
     public LeaveApplication approveLeave(Long applicationId,
-             
-    		String approverId,
+                                         String approverId,
                                          String comments) {
 
         LeaveApplication application = getLeaveById(applicationId);
@@ -143,14 +141,19 @@ public class LeaveServiceImpl implements LeaveService {
             );
         }
 
-        Employee manager = employeeRepository.findById(approverId)
+        Employee approver = employeeRepository.findById(approverId)
                 .orElseThrow(() ->
                         new ResourceNotFoundException("Employee", "employeeId", approverId));
 
-        if (application.getEmployee().getManager() == null ||
+        boolean isAdmin = approver.hasRole("ADMIN");
+
+        if (!isAdmin) {
+            if (application.getEmployee().getManager() == null ||
                 !application.getEmployee().getManager().getEmployeeId()
-                        .equals(manager.getEmployeeId())) {
-            throw new UnauthorizedException("Not authorized to approve this leave");
+                        .equals(approver.getEmployeeId())) {
+
+                throw new UnauthorizedException("Not authorized to approve this leave");
+            }
         }
 
         LeaveBalance balance = getOrCreateLeaveBalance(
@@ -165,7 +168,7 @@ public class LeaveServiceImpl implements LeaveService {
         balance.setBalance(balance.getBalance() - application.getTotalDays());
 
         application.setStatus(LeaveStatus.APPROVED);
-        application.setApprovedBy(manager);
+        application.setApprovedBy(approver);
         application.setApprovedOn(LocalDateTime.now());
         application.setComments(comments);
 
@@ -192,18 +195,28 @@ public class LeaveServiceImpl implements LeaveService {
             );
         }
 
-        Employee manager = employeeRepository.findById(approverId)
+        Employee approver = employeeRepository.findById(approverId)
                 .orElseThrow(() ->
                         new ResourceNotFoundException("Employee", "employeeId", approverId));
 
+        boolean isAdmin = approver.hasRole("ADMIN");
+
+        if (!isAdmin) {
+            if (application.getEmployee().getManager() == null ||
+                !application.getEmployee().getManager().getEmployeeId()
+                        .equals(approver.getEmployeeId())) {
+
+                throw new UnauthorizedException("Not authorized to reject this leave");
+            }
+        }
+
         application.setStatus(LeaveStatus.REJECTED);
-        application.setApprovedBy(manager);
+        application.setApprovedBy(approver);
         application.setApprovedOn(LocalDateTime.now());
         application.setRejectionReason(rejectionReason);
 
         return leaveApplicationRepository.save(application);
     }
-
     // =========================================================
     // BALANCES
     // =========================================================


### PR DESCRIPTION
@MastanSayyad 
Summary

Implemented hierarchical Role-Based Access Control (RBAC) across Leave module endpoints to ensure structured access permissions.

RBAC Hierarchy Implemented

- ADMIN → Can access Admin + Manager + Employee features
- MANAGER → Can access Manager + Employee features
- EMPLOYEE → Can access Employee features only

Endpoint Access Rules

Employee Endpoints:
Accessible by: EMPLOYEE, MANAGER, ADMIN

- Apply Leave
- View Leave History
- Cancel Leave
- View Leave Balance

Manager Endpoints
Accessible by: MANAGER, ADMIN

- View Pending Leave Requests
- View Team Leave History
- Review Leave Details
- Approve Leave
- Reject Leave

Admin Endpoints
Accessible by: ADMIN only
Admin Dashboard
Employee Management
System-Level Operations

Service-Level Authorization Enhancements

- Managers can approve/reject leave requests only for their team members.
- Admin can approve/reject leave requests for any employee.
- Unauthorized access attempts throw UnauthorizedException.

Security Improvements

- Added @PreAuthorize annotations to enforce endpoint-level RBAC.
- Implemented hierarchical role behavior without privilege escalation.
- Ensured strict separation of responsibilities across roles.

Result

Clean hierarchical RBAC model implemented.
No cross-role privilege leaks.
Proper enterprise-level access control enforcement.