### PR TITLE
Add Department/Designation CRUD UI & fix Employee form bugs

### DIFF
--- a/src/main/java/com/revature/revworkforce/controller/EmployeeController.java
+++ b/src/main/java/com/revature/revworkforce/controller/EmployeeController.java
@@ -20,14 +20,15 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * Employee Controller.
- * 
+ *
  * Handles employee management endpoints.
- * 
+ *
  * @author RevWorkForce Team
  */
 @Controller
@@ -47,6 +48,12 @@ public class EmployeeController {
 
     @Autowired
     private RoleRepository roleRepository;
+
+    /**
+     * Role names allowed to appear in the Reporting Manager dropdown.
+     * Both MANAGER and ADMIN employees can be assigned as reporting managers.
+     */
+    private static final List<String> MANAGER_ROLE_NAMES = Arrays.asList("MANAGER", "ADMIN");
 
     // ============================================
     // ADMIN API ENDPOINTS
@@ -117,15 +124,14 @@ public class EmployeeController {
     @PreAuthorize("hasRole('ADMIN')")
     public String showAddEmployeeForm(Model model) {
         EmployeeDTO dto = new EmployeeDTO();
-        // Start with empty ID; JS will auto-fill based on role selection
         dto.setEmployeeId("");
 
         model.addAttribute("employeeDTO", dto);
         model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
         model.addAttribute("designations", designationRepository.findByIsActive('Y'));
-        // Only show MANAGER-role employees in the Reporting Manager dropdown
+        // Show both MANAGER and ADMIN employees in the Reporting Manager dropdown
         model.addAttribute("managers",
-                employeeRepository.findActiveEmployeesByRoleName("MANAGER"));
+                employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
         model.addAttribute("roles", roleRepository.findAll());
         model.addAttribute("statuses", EmployeeStatus.values());
         model.addAttribute("pageTitle", "Add Employee");
@@ -148,10 +154,16 @@ public class EmployeeController {
         if (result.hasErrors()) {
             model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
             model.addAttribute("designations", designationRepository.findByIsActive('Y'));
-            model.addAttribute("managers", employeeRepository.findActiveEmployeesByRoleName("MANAGER"));
+            model.addAttribute("managers",
+                    employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
             model.addAttribute("roles", roleRepository.findAll());
             model.addAttribute("statuses", EmployeeStatus.values());
             model.addAttribute("isEdit", false);
+            // Build a readable error summary from binding result
+            String errorSummary = result.getAllErrors().stream()
+                    .map(e -> e.getDefaultMessage())
+                    .collect(Collectors.joining("; "));
+            model.addAttribute("error", "Please fix the following errors: " + errorSummary);
             return "pages/admin/employee-form";
         }
 
@@ -162,10 +174,12 @@ public class EmployeeController {
                             + ") added successfully!");
             return "redirect:/admin/employees";
         } catch (Exception e) {
-            model.addAttribute("error", e.getMessage());
+            model.addAttribute("error", e.getMessage() != null ? e.getMessage()
+                    : "An unexpected error occurred while saving the employee. Please try again.");
             model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
             model.addAttribute("designations", designationRepository.findByIsActive('Y'));
-            model.addAttribute("managers", employeeRepository.findActiveEmployeesByRoleName("MANAGER"));
+            model.addAttribute("managers",
+                    employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
             model.addAttribute("roles", roleRepository.findAll());
             model.addAttribute("statuses", EmployeeStatus.values());
             model.addAttribute("isEdit", false);
@@ -185,8 +199,9 @@ public class EmployeeController {
         model.addAttribute("employeeDTO", dto);
         model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
         model.addAttribute("designations", designationRepository.findByIsActive('Y'));
+        // Show both MANAGER and ADMIN employees in the Reporting Manager dropdown
         model.addAttribute("managers",
-                employeeRepository.findActiveEmployeesByRoleName("MANAGER"));
+                employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
         model.addAttribute("roles", roleRepository.findAll());
         model.addAttribute("statuses", EmployeeStatus.values());
         model.addAttribute("pageTitle", "Edit Employee");
@@ -210,11 +225,16 @@ public class EmployeeController {
         if (result.hasErrors()) {
             model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
             model.addAttribute("designations", designationRepository.findByIsActive('Y'));
-            model.addAttribute("managers", employeeService.getActiveEmployees());
+            model.addAttribute("managers",
+                    employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
             model.addAttribute("roles", roleRepository.findAll());
             model.addAttribute("statuses", EmployeeStatus.values());
             model.addAttribute("isEdit", true);
-            return "admin/employees/form";
+            String errorSummary = result.getAllErrors().stream()
+                    .map(e -> e.getDefaultMessage())
+                    .collect(Collectors.joining("; "));
+            model.addAttribute("error", "Please fix the following errors: " + errorSummary);
+            return "pages/admin/employee-form";
         }
 
         try {
@@ -223,14 +243,16 @@ public class EmployeeController {
                     "Employee " + employee.getFullName() + " updated successfully!");
             return "redirect:/admin/employees";
         } catch (Exception e) {
-            model.addAttribute("error", e.getMessage());
+            model.addAttribute("error", e.getMessage() != null ? e.getMessage()
+                    : "An unexpected error occurred while updating the employee. Please try again.");
             model.addAttribute("departments", departmentRepository.findByIsActive('Y'));
             model.addAttribute("designations", designationRepository.findByIsActive('Y'));
-            model.addAttribute("managers", employeeService.getActiveEmployees());
+            model.addAttribute("managers",
+                    employeeRepository.findActiveEmployeesByRoleNames(MANAGER_ROLE_NAMES));
             model.addAttribute("roles", roleRepository.findAll());
             model.addAttribute("statuses", EmployeeStatus.values());
             model.addAttribute("isEdit", true);
-            return "admin/employees/form";
+            return "pages/admin/employee-form";
         }
     }
 
@@ -243,7 +265,6 @@ public class EmployeeController {
         Employee employee = employeeService.getEmployeeById(employeeId);
         EmployeeDTO dto = employeeService.convertToDTO(employee);
 
-        // Get team members if this is a manager
         List<Employee> teamMembers = employeeService.getTeamMembers(employeeId);
 
         model.addAttribute("employee", dto);
@@ -349,7 +370,6 @@ public class EmployeeController {
         }
 
         try {
-            // Only allow updating specific fields
             Employee employee = employeeService.getEmployeeById(employeeId);
             employee.setPhone(dto.getPhone());
             employee.setAddress(dto.getAddress());
@@ -359,7 +379,6 @@ public class EmployeeController {
             employee.setEmergencyContactName(dto.getEmergencyContactName());
             employee.setEmergencyContactPhone(dto.getEmergencyContactPhone());
 
-            // Note: Convert to DTO and back to use the existing update method
             EmployeeDTO fullDto = employeeService.convertToDTO(employee);
             fullDto.setPhone(dto.getPhone());
             fullDto.setAddress(dto.getAddress());
@@ -397,7 +416,6 @@ public class EmployeeController {
         List<Employee> employees;
 
         if (search != null || departmentId != null || designationId != null) {
-            // Build search criteria
             EmployeeSearchCriteria criteria = new EmployeeSearchCriteria();
             criteria.setKeyword(search);
             criteria.setDepartmentId(departmentId);
@@ -406,7 +424,6 @@ public class EmployeeController {
 
             employees = employeeService.searchEmployees(criteria);
         } else {
-            // Show only active employees
             employees = employeeService.getActiveEmployees();
         }
 

--- a/src/main/java/com/revature/revworkforce/repository/EmployeeRepository.java
+++ b/src/main/java/com/revature/revworkforce/repository/EmployeeRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,68 +25,41 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
 
        /**
         * Find employee by email.
-        * 
-        * @param email the email address
-        * @return Optional containing the employee if found
         */
        Optional<Employee> findByEmail(String email);
 
        /**
-        * Find employee by email or employee ID.
-        * Used for login.
-        * 
-        * @param email      the email address
-        * @param employeeId the employee ID
-        * @return Optional containing the employee if found
+        * Find employee by email or employee ID. Used for login.
         */
        Optional<Employee> findByEmailOrEmployeeId(String email, String employeeId);
 
        /**
         * Find all employees by status.
-        * 
-        * @param status the employee status
-        * @return list of employees
         */
        List<Employee> findByStatus(EmployeeStatus status);
 
        /**
         * Find all employees by department.
-        * 
-        * @param department the department
-        * @return list of employees
         */
        List<Employee> findByDepartment(Department department);
 
        /**
         * Find all employees by designation.
-        * 
-        * @param designation the designation
-        * @return list of employees
         */
        List<Employee> findByDesignation(Designation designation);
 
        /**
         * Find all employees reporting to a manager.
-        * 
-        * @param manager the manager employee
-        * @return list of employees
         */
        List<Employee> findByManager(Employee manager);
 
        /**
         * Find all employees by manager ID.
-        * 
-        * @param managerId the manager's employee ID
-        * @return list of employees
         */
        List<Employee> findByManager_EmployeeId(String managerId);
 
        /**
         * Search employees by name (first name or last name).
-        * 
-        * @param firstName the first name
-        * @param lastName  the last name
-        * @return list of employees
         */
        @Query("SELECT e FROM Employee e WHERE " +
                      "LOWER(e.firstName) LIKE LOWER(CONCAT('%', :firstName, '%')) OR " +
@@ -95,9 +69,6 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
 
        /**
         * Search employees by keyword (searches in name, email, employee ID).
-        * 
-        * @param keyword the search keyword
-        * @return list of employees
         */
        @Query("SELECT e FROM Employee e WHERE " +
                      "LOWER(e.firstName) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
@@ -107,115 +78,77 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
        List<Employee> searchByKeyword(@Param("keyword") String keyword);
 
        /**
-        * Find all active employees.
-        * 
-        * @return list of active employees
+        * Find all active employees ordered by first name.
         */
        List<Employee> findByStatusOrderByFirstNameAsc(EmployeeStatus status);
 
        /**
         * Count employees by department.
-        * 
-        * @param department the department
-        * @return count of employees
         */
        long countByDepartment(Department department);
 
        /**
         * Count employees by designation.
-        * 
-        * @param designation the designation
-        * @return count of employees
         */
        long countByDesignation(Designation designation);
 
        /**
         * Count employees by status.
-        * 
-        * @param status the employee status
-        * @return count of employees
         */
        long countByStatus(EmployeeStatus status);
 
        /**
         * Check if email exists.
-        * 
-        * @param email the email address
-        * @return true if exists
         */
        boolean existsByEmail(String email);
 
        /**
         * Check if employee ID exists.
-        * 
-        * @param employeeId the employee ID
-        * @return true if exists
         */
        boolean existsById(String employeeId);
 
        /**
         * Find employees by department and status.
-        * 
-        * @param department the department
-        * @param status     the employee status
-        * @return list of employees
         */
        List<Employee> findByDepartmentAndStatus(Department department, EmployeeStatus status);
 
        /**
         * Count employees grouped by status.
-        * 
-        * @return List of Object arrays where [0] is EmployeeStatus and [1] is the
-        *         count.
         */
        @Query("SELECT e.status, COUNT(e) FROM Employee e GROUP BY e.status")
        List<Object[]> countEmployeesByStatus();
 
        /**
         * Count employees grouped by department.
-        * 
-        * @return List of Object arrays where [0] is Department and [1] is the count.
         */
        @Query("SELECT e.department.departmentName, COUNT(e) FROM Employee e GROUP BY e.department.departmentName")
        List<Object[]> countEmployeesByDepartment();
 
        /**
         * Count employees grouped by designation.
-        * 
-        * @return List of Object arrays where [0] is Designation and [1] is the count.
         */
        @Query("SELECT e.designation.designationName, COUNT(e) FROM Employee e GROUP BY e.designation.designationName")
        List<Object[]> countEmployeesByDesignation();
 
        /**
         * Count employees grouped by gender.
-        * 
-        * @return List of Object arrays where [0] is Gender and [1] is the count.
         */
        @Query("SELECT e.gender, COUNT(e) FROM Employee e GROUP BY e.gender")
        List<Object[]> countEmployeesByGender();
 
        /**
         * Get average employee tenure in years.
-        * 
-        * @return Average tenure
         */
        @Query("SELECT AVG(EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM e.joiningDate)) FROM Employee e WHERE e.joiningDate IS NOT NULL")
        Double getAverageTenure();
 
        /**
         * Find employees by account locked status.
-        * 
-        * @param accountLocked the locked status ('Y' or 'N')
-        * @return list of employees
         */
        List<Employee> findByAccountLocked(Character accountLocked);
 
        /**
         * Find employees by first login status.
-        * 
-        * @param firstLogin the first login status ('Y' or 'N')
-        * @return list of employees
         */
        List<Employee> findByFirstLogin(Character firstLogin);
 
@@ -228,4 +161,15 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
                      + "AND e.status = com.revature.revworkforce.enums.EmployeeStatus.ACTIVE "
                      + "ORDER BY e.firstName ASC")
        List<Employee> findActiveEmployeesByRoleName(@Param("roleName") String roleName);
+
+       /**
+        * Find all ACTIVE employees that have any of the given role names.
+        * Used to populate the Reporting Manager dropdown with both MANAGER and ADMIN
+        * employees.
+        */
+       @Query("SELECT DISTINCT e FROM Employee e JOIN e.roles r "
+                     + "WHERE UPPER(r.roleName) IN :roleNames "
+                     + "AND e.status = com.revature.revworkforce.enums.EmployeeStatus.ACTIVE "
+                     + "ORDER BY e.firstName ASC")
+       List<Employee> findActiveEmployeesByRoleNames(@Param("roleNames") Collection<String> roleNames);
 }

--- a/src/main/resources/templates/frontend/admin/departments/form.html
+++ b/src/main/resources/templates/frontend/admin/departments/form.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${isEdit ? 'Edit Department' : 'Add Department'} + ' - RevWorkForce Admin'">Department Form</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <style>
+        .section-title {
+            color: var(--primary);
+            border-bottom: 2px solid rgba(255, 140, 0, 0.15);
+            padding-bottom: 0.5rem;
+            margin: 1.5rem 0 1rem;
+            font-size: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .form-label .required {
+            color: #e53935;
+            margin-left: 2px;
+        }
+
+        .field-hint {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            margin-top: 0.25rem;
+        }
+
+        .text-danger {
+            font-size: 0.78rem;
+            color: #e53935;
+            margin-top: 0.25rem;
+            display: block;
+        }
+
+        .field-grid-2 {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1rem;
+        }
+
+        @media (max-width: 768px) {
+            .field-grid-2 {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .char-counter {
+            font-size: 0.72rem;
+            color: var(--text-muted);
+            text-align: right;
+            margin-top: 0.2rem;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-container">
+        <app-sidebar></app-sidebar>
+        <main class="main-content">
+            <app-navbar th:attr="page-title=${isEdit ? 'Edit Department' : 'Add Department'}"></app-navbar>
+            <div class="page-wrapper">
+
+                <!-- Flash messages -->
+                <div th:if="${error}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#f8d7da; border-radius:6px; color:#721c24; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <span th:text="${error}">Error</span>
+                </div>
+
+                <div class="card">
+                    <!-- Header -->
+                    <div class="flex-space-between" style="margin-bottom:1.5rem;">
+                        <div>
+                            <h3 style="margin:0;" th:text="${isEdit ? 'Edit Department' : 'Add New Department'}">
+                                Department Form
+                            </h3>
+                            <p class="text-muted" style="margin:0.2rem 0 0; font-size:0.85rem;">
+                                Fields marked with <span style="color:#e53935;">*</span> are required
+                            </p>
+                        </div>
+                        <a th:href="@{/admin/departments}" class="btn btn-secondary btn-sm">
+                            <i class="fas fa-arrow-left"></i> Back to List
+                        </a>
+                    </div>
+
+                    <form id="deptForm"
+                        th:action="${isEdit ? '/admin/departments/edit/' + departmentDTO.departmentId : '/admin/departments/add'}"
+                        method="post" th:object="${departmentDTO}" novalidate>
+
+                        <!-- Department Name -->
+                        <h4 class="section-title"><i class="fas fa-building"></i> Department Details</h4>
+                        <div class="field-grid-2">
+                            <div class="form-group">
+                                <label class="form-label">
+                                    Department Name <span class="required">*</span>
+                                </label>
+                                <input type="text" class="form-control" th:field="*{departmentName}"
+                                    placeholder="e.g. Engineering, Human Resources" maxlength="100" required
+                                    th:classappend="${#fields.hasErrors('departmentName')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('departmentName')}"
+                                    th:errors="*{departmentName}"></span>
+                                <div class="field-hint">Must be unique. 2–100 characters.</div>
+                            </div>
+
+                            <div class="form-group">
+                                <label class="form-label">Department Head</label>
+                                <input type="text" class="form-control" th:field="*{departmentHead}"
+                                    placeholder="e.g. EMP001 or Full Name" maxlength="20"
+                                    th:classappend="${#fields.hasErrors('departmentHead')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('departmentHead')}"
+                                    th:errors="*{departmentHead}"></span>
+                                <div class="field-hint">Optional — Employee ID or name. Max 20 chars.</div>
+                            </div>
+                        </div>
+
+                        <!-- Description -->
+                        <div class="form-group">
+                            <label class="form-label">Description</label>
+                            <textarea class="form-control" th:field="*{description}" id="descriptionArea"
+                                placeholder="Brief overview of this department's function and responsibilities…"
+                                rows="4" maxlength="500"
+                                th:classappend="${#fields.hasErrors('description')} ? 'is-invalid' : ''"></textarea>
+                            <span class="text-danger" th:if="${#fields.hasErrors('description')}"
+                                th:errors="*{description}"></span>
+                            <div class="char-counter"><span id="descCount">0</span> / 500</div>
+                        </div>
+
+                        <!-- Status -->
+                        <h4 class="section-title"><i class="fas fa-toggle-on"></i> Status</h4>
+                        <div class="form-group" style="max-width:200px;">
+                            <label class="form-label">Active Status</label>
+                            <select class="form-control" th:field="*{isActive}">
+                                <option value="Y">Active</option>
+                                <option value="N">Inactive</option>
+                            </select>
+                            <div class="field-hint">Inactive departments won't appear in employee assignment.</div>
+                        </div>
+
+                        <!-- Actions -->
+                        <div
+                            style="display:flex; gap:1rem; padding-top:1.5rem; border-top:1px solid var(--border-color); margin-top:1.5rem;">
+                            <button type="submit" id="submitBtn" class="btn btn-primary">
+                                <i class="fas fa-save"></i>
+                                <span th:text="${isEdit ? 'Update Department' : 'Add Department'}">Save</span>
+                            </button>
+                            <a th:href="@{/admin/departments}" class="btn btn-secondary">
+                                <i class="fas fa-times"></i> Cancel
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script th:src="@{/js/components.js}"></script>
+    <script th:src="@{/js/app.js}"></script>
+    <script>
+        // Character counter for description
+        const descArea = document.getElementById('descriptionArea');
+        const descCount = document.getElementById('descCount');
+        if (descArea && descCount) {
+            function updateCount() { descCount.textContent = descArea.value.length; }
+            updateCount();
+            descArea.addEventListener('input', updateCount);
+        }
+
+        // Prevent double-submit
+        document.getElementById('deptForm').addEventListener('submit', function () {
+            const btn = document.getElementById('submitBtn');
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving…';
+        });
+    </script>
+</body>
+
+</html>

--- a/src/main/resources/templates/frontend/admin/departments/list.html
+++ b/src/main/resources/templates/frontend/admin/departments/list.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Department Management - RevWorkForce Admin</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <style>
+        .badge-active {
+            background: rgba(16, 185, 129, 0.15);
+            color: #10b981;
+            padding: 0.25rem 0.6rem;
+            border-radius: 99px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .badge-inactive {
+            background: rgba(239, 68, 68, 0.12);
+            color: #ef4444;
+            padding: 0.25rem 0.6rem;
+            border-radius: 99px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .page-actions {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 1.25rem;
+        }
+
+        .page-actions h2 {
+            margin: 0;
+            font-size: 1.2rem;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-container">
+        <app-sidebar></app-sidebar>
+        <main class="main-content">
+            <app-navbar page-title="Department Management"></app-navbar>
+            <div class="page-wrapper">
+
+                <!-- Flash messages -->
+                <div th:if="${success}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#d4edda; border-radius:6px; color:#155724; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-check-circle"></i>
+                    <span th:text="${success}">Success</span>
+                </div>
+                <div th:if="${error}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#f8d7da; border-radius:6px; color:#721c24; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <span th:text="${error}">Error</span>
+                </div>
+
+                <div class="card">
+                    <div class="page-actions">
+                        <div>
+                            <h2><i class="fas fa-building"
+                                    style="color:var(--primary); margin-right:0.5rem;"></i>Departments</h2>
+                            <p class="text-muted" style="margin:0.15rem 0 0; font-size:0.85rem;"
+                                th:text="${'Total: ' + departments.size() + ' department(s)'}">Total: 0 departments</p>
+                        </div>
+                        <div style="display:flex; gap:0.75rem; align-items:center;">
+                            <a th:href="@{/admin/system-config}" class="btn btn-secondary btn-sm">
+                                <i class="fas fa-arrow-left"></i> Back to Config
+                            </a>
+                            <a th:href="@{/admin/departments/add}" class="btn btn-primary">
+                                <i class="fas fa-plus"></i> Add Department
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Department Name</th>
+                                    <th>Department Head</th>
+                                    <th>Employees</th>
+                                    <th>Status</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="dept, stat : ${departments}">
+                                    <td th:text="${stat.index + 1}" style="color:var(--text-muted); width:50px;">1</td>
+                                    <td>
+                                        <span style="font-weight:600;"
+                                            th:text="${dept.departmentName}">Engineering</span>
+                                    </td>
+                                    <td th:text="${dept.departmentHead != null ? dept.departmentHead : '—'}">John Doe
+                                    </td>
+                                    <td>
+                                        <span class="badge bg-info" th:text="${dept.employeeCount + ' member(s)'}">0
+                                            member(s)</span>
+                                    </td>
+                                    <td>
+                                        <span th:if="${dept.isActive == 'Y'}" class="badge-active">
+                                            <i class="fas fa-circle"
+                                                style="font-size:0.5rem; margin-right:3px;"></i>Active
+                                        </span>
+                                        <span th:unless="${dept.isActive == 'Y'}" class="badge-inactive">
+                                            <i class="fas fa-circle"
+                                                style="font-size:0.5rem; margin-right:3px;"></i>Inactive
+                                        </span>
+                                    </td>
+                                    <td style="display:flex; gap:0.4rem; flex-wrap:wrap;">
+                                        <a th:href="@{/admin/departments/edit/{id}(id=${dept.departmentId})}"
+                                            class="btn btn-secondary btn-sm">
+                                            <i class="fas fa-edit"></i> Edit
+                                        </a>
+                                        <form th:action="@{/admin/departments/delete/{id}(id=${dept.departmentId})}"
+                                            method="POST" style="display:inline;"
+                                            onsubmit="return confirm('Delete department \'' + this.dataset.name + '\'? This action cannot be undone.');"
+                                            th:data-name="${dept.departmentName}">
+                                            <button type="submit" class="btn btn-danger btn-sm">
+                                                <i class="fas fa-trash"></i> Delete
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                                <tr th:if="${#lists.isEmpty(departments)}">
+                                    <td colspan="6" class="text-center text-muted" style="padding:3rem;">
+                                        <i class="fas fa-building"
+                                            style="font-size:2rem; opacity:0.3; display:block; margin-bottom:0.75rem;"></i>
+                                        No departments found. <a th:href="@{/admin/departments/add}">Add the first
+                                            one.</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
+        </main>
+    </div>
+    <script th:src="@{/js/components.js}"></script>
+    <script th:src="@{/js/app.js}"></script>
+</body>
+
+</html>

--- a/src/main/resources/templates/frontend/admin/designations/form.html
+++ b/src/main/resources/templates/frontend/admin/designations/form.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${isEdit ? 'Edit Designation' : 'Add Designation'} + ' - RevWorkForce Admin'">Designation Form
+    </title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <style>
+        .section-title {
+            color: var(--primary);
+            border-bottom: 2px solid rgba(255, 140, 0, 0.15);
+            padding-bottom: 0.5rem;
+            margin: 1.5rem 0 1rem;
+            font-size: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .form-label .required {
+            color: #e53935;
+            margin-left: 2px;
+        }
+
+        .field-hint {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            margin-top: 0.25rem;
+        }
+
+        .text-danger {
+            font-size: 0.78rem;
+            color: #e53935;
+            margin-top: 0.25rem;
+            display: block;
+        }
+
+        .field-grid-2 {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1rem;
+        }
+
+        .field-grid-3 {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1rem;
+        }
+
+        @media (max-width: 768px) {
+
+            .field-grid-2,
+            .field-grid-3 {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .char-counter {
+            font-size: 0.72rem;
+            color: var(--text-muted);
+            text-align: right;
+            margin-top: 0.2rem;
+        }
+
+        #salaryWarning {
+            display: none;
+            font-size: 0.78rem;
+            color: #e53935;
+            margin-top: 0.3rem;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-container">
+        <app-sidebar></app-sidebar>
+        <main class="main-content">
+            <app-navbar th:attr="page-title=${isEdit ? 'Edit Designation' : 'Add Designation'}"></app-navbar>
+            <div class="page-wrapper">
+
+                <!-- Flash messages -->
+                <div th:if="${error}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#f8d7da; border-radius:6px; color:#721c24; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <span th:text="${error}">Error</span>
+                </div>
+
+                <div class="card">
+                    <!-- Header -->
+                    <div class="flex-space-between" style="margin-bottom:1.5rem;">
+                        <div>
+                            <h3 style="margin:0;" th:text="${isEdit ? 'Edit Designation' : 'Add New Designation'}">
+                                Designation Form
+                            </h3>
+                            <p class="text-muted" style="margin:0.2rem 0 0; font-size:0.85rem;">
+                                Fields marked with <span style="color:#e53935;">*</span> are required
+                            </p>
+                        </div>
+                        <a th:href="@{/admin/designations}" class="btn btn-secondary btn-sm">
+                            <i class="fas fa-arrow-left"></i> Back to List
+                        </a>
+                    </div>
+
+                    <form id="desigForm"
+                        th:action="${isEdit ? '/admin/designations/edit/' + designationDTO.designationId : '/admin/designations/add'}"
+                        method="post" th:object="${designationDTO}" novalidate>
+
+                        <!-- Basic Info -->
+                        <h4 class="section-title"><i class="fas fa-id-badge"></i> Designation Details</h4>
+                        <div class="field-grid-2">
+                            <div class="form-group">
+                                <label class="form-label">
+                                    Designation Name <span class="required">*</span>
+                                </label>
+                                <input type="text" class="form-control" th:field="*{designationName}"
+                                    placeholder="e.g. Software Engineer, Senior Analyst" maxlength="100" required
+                                    th:classappend="${#fields.hasErrors('designationName')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('designationName')}"
+                                    th:errors="*{designationName}"></span>
+                                <div class="field-hint">Must be unique. 2–100 characters.</div>
+                            </div>
+
+                            <div class="form-group">
+                                <label class="form-label">Level / Band</label>
+                                <input type="text" class="form-control" th:field="*{designationLevel}"
+                                    placeholder="e.g. L1, L2, Senior, Junior" maxlength="20"
+                                    th:classappend="${#fields.hasErrors('designationLevel')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('designationLevel')}"
+                                    th:errors="*{designationLevel}"></span>
+                                <div class="field-hint">Optional — career band or seniority tier. Max 20 chars.</div>
+                            </div>
+                        </div>
+
+                        <!-- Salary Range -->
+                        <h4 class="section-title"><i class="fas fa-rupee-sign"></i> Salary Range (₹)</h4>
+                        <div class="field-grid-3" style="align-items:start;">
+                            <div class="form-group">
+                                <label class="form-label">Minimum Salary</label>
+                                <input type="number" id="minSalary" class="form-control" th:field="*{minSalary}"
+                                    placeholder="e.g. 300000" min="0" step="1000"
+                                    th:classappend="${#fields.hasErrors('minSalary')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('minSalary')}"
+                                    th:errors="*{minSalary}"></span>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Maximum Salary</label>
+                                <input type="number" id="maxSalary" class="form-control" th:field="*{maxSalary}"
+                                    placeholder="e.g. 800000" min="0" step="1000"
+                                    th:classappend="${#fields.hasErrors('maxSalary')} ? 'is-invalid' : ''">
+                                <span class="text-danger" th:if="${#fields.hasErrors('maxSalary')}"
+                                    th:errors="*{maxSalary}"></span>
+                                <span id="salaryWarning">Max salary must be ≥ Min salary</span>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Range Preview</label>
+                                <div id="salaryPreview"
+                                    style="background:rgba(255,140,0,0.07); border:1px solid rgba(255,140,0,0.25); border-radius:6px; padding:0.6rem 0.9rem; font-size:0.85rem; color:var(--primary); font-weight:600; min-height:38px; display:flex; align-items:center;">
+                                    —
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Description -->
+                        <div class="form-group">
+                            <label class="form-label">Description</label>
+                            <textarea class="form-control" th:field="*{description}" id="descriptionArea"
+                                placeholder="Describe responsibilities, qualifications, or expectations for this role…"
+                                rows="4" maxlength="500"
+                                th:classappend="${#fields.hasErrors('description')} ? 'is-invalid' : ''"></textarea>
+                            <span class="text-danger" th:if="${#fields.hasErrors('description')}"
+                                th:errors="*{description}"></span>
+                            <div class="char-counter"><span id="descCount">0</span> / 500</div>
+                        </div>
+
+                        <!-- Status -->
+                        <h4 class="section-title"><i class="fas fa-toggle-on"></i> Status</h4>
+                        <div class="form-group" style="max-width:200px;">
+                            <label class="form-label">Active Status</label>
+                            <select class="form-control" th:field="*{isActive}">
+                                <option value="Y">Active</option>
+                                <option value="N">Inactive</option>
+                            </select>
+                            <div class="field-hint">Inactive designations won't appear in employee assignment.</div>
+                        </div>
+
+                        <!-- Actions -->
+                        <div
+                            style="display:flex; gap:1rem; padding-top:1.5rem; border-top:1px solid var(--border-color); margin-top:1.5rem;">
+                            <button type="submit" id="submitBtn" class="btn btn-primary">
+                                <i class="fas fa-save"></i>
+                                <span th:text="${isEdit ? 'Update Designation' : 'Add Designation'}">Save</span>
+                            </button>
+                            <a th:href="@{/admin/designations}" class="btn btn-secondary">
+                                <i class="fas fa-times"></i> Cancel
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script th:src="@{/js/components.js}"></script>
+    <script th:src="@{/js/app.js}"></script>
+    <script>
+        // ── Character counter for description
+        const descArea = document.getElementById('descriptionArea');
+        const descCount = document.getElementById('descCount');
+        if (descArea && descCount) {
+            function updateCount() { descCount.textContent = descArea.value.length; }
+            updateCount();
+            descArea.addEventListener('input', updateCount);
+        }
+
+        // ── Salary range preview
+        const minInput = document.getElementById('minSalary');
+        const maxInput = document.getElementById('maxSalary');
+        const preview = document.getElementById('salaryPreview');
+        const salaryWarning = document.getElementById('salaryWarning');
+
+        function formatCurrency(val) {
+            if (!val || isNaN(val)) return '?';
+            return '₹' + Number(val).toLocaleString('en-IN');
+        }
+
+        function updateSalaryPreview() {
+            const min = parseFloat(minInput.value);
+            const max = parseFloat(maxInput.value);
+            if (min >= 0 && max >= 0 && (minInput.value || maxInput.value)) {
+                preview.textContent = formatCurrency(min) + ' – ' + formatCurrency(max);
+                if (max < min && minInput.value && maxInput.value) {
+                    salaryWarning.style.display = 'block';
+                    preview.style.color = '#e53935';
+                } else {
+                    salaryWarning.style.display = 'none';
+                    preview.style.color = 'var(--primary)';
+                }
+            } else {
+                preview.textContent = '—';
+            }
+        }
+
+        if (minInput) { minInput.addEventListener('input', updateSalaryPreview); updateSalaryPreview(); }
+        if (maxInput) { maxInput.addEventListener('input', updateSalaryPreview); }
+
+        // ── Prevent double-submit + salary validation
+        document.getElementById('desigForm').addEventListener('submit', function (e) {
+            const min = parseFloat(minInput.value);
+            const max = parseFloat(maxInput.value);
+            if (minInput.value && maxInput.value && max < min) {
+                e.preventDefault();
+                salaryWarning.style.display = 'block';
+                maxInput.focus();
+                return;
+            }
+            const btn = document.getElementById('submitBtn');
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving…';
+        });
+    </script>
+</body>
+
+</html>

--- a/src/main/resources/templates/frontend/admin/designations/list.html
+++ b/src/main/resources/templates/frontend/admin/designations/list.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Designation Management - RevWorkForce Admin</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <style>
+        .badge-active {
+            background: rgba(16, 185, 129, 0.15);
+            color: #10b981;
+            padding: 0.25rem 0.6rem;
+            border-radius: 99px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .badge-inactive {
+            background: rgba(239, 68, 68, 0.12);
+            color: #ef4444;
+            padding: 0.25rem 0.6rem;
+            border-radius: 99px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .page-actions {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 1.25rem;
+        }
+
+        .page-actions h2 {
+            margin: 0;
+            font-size: 1.2rem;
+        }
+
+        .salary-range {
+            font-size: 0.82rem;
+            color: var(--text-muted);
+        }
+    </style>
+</head>
+
+<body>
+    <div class="app-container">
+        <app-sidebar></app-sidebar>
+        <main class="main-content">
+            <app-navbar page-title="Designation Management"></app-navbar>
+            <div class="page-wrapper">
+
+                <!-- Flash messages -->
+                <div th:if="${success}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#d4edda; border-radius:6px; color:#155724; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-check-circle"></i>
+                    <span th:text="${success}">Success</span>
+                </div>
+                <div th:if="${error}"
+                    style="margin-bottom:1rem; padding:0.75rem 1rem; background:#f8d7da; border-radius:6px; color:#721c24; display:flex; align-items:center; gap:0.5rem;">
+                    <i class="fas fa-exclamation-circle"></i>
+                    <span th:text="${error}">Error</span>
+                </div>
+
+                <div class="card">
+                    <div class="page-actions">
+                        <div>
+                            <h2><i class="fas fa-id-badge"
+                                    style="color:var(--primary); margin-right:0.5rem;"></i>Designations</h2>
+                            <p class="text-muted" style="margin:0.15rem 0 0; font-size:0.85rem;"
+                                th:text="${'Total: ' + designations.size() + ' designation(s)'}">Total: 0 designations
+                            </p>
+                        </div>
+                        <div style="display:flex; gap:0.75rem; align-items:center;">
+                            <a th:href="@{/admin/system-config}" class="btn btn-secondary btn-sm">
+                                <i class="fas fa-arrow-left"></i> Back to Config
+                            </a>
+                            <a th:href="@{/admin/designations/add}" class="btn btn-primary">
+                                <i class="fas fa-plus"></i> Add Designation
+                            </a>
+                        </div>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Designation Name</th>
+                                    <th>Level / Band</th>
+                                    <th>Salary Range</th>
+                                    <th>Employees</th>
+                                    <th>Status</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr th:each="desig, stat : ${designations}">
+                                    <td th:text="${stat.index + 1}" style="color:var(--text-muted); width:50px;">1</td>
+                                    <td>
+                                        <span style="font-weight:600;" th:text="${desig.designationName}">Software
+                                            Engineer</span>
+                                    </td>
+                                    <td>
+                                        <span th:if="${desig.designationLevel != null}"
+                                            style="background:rgba(255,140,0,0.1); color:var(--primary); padding:0.2rem 0.55rem; border-radius:4px; font-size:0.8rem; font-weight:600;"
+                                            th:text="${desig.designationLevel}">L3</span>
+                                        <span th:unless="${desig.designationLevel != null}" class="text-muted">—</span>
+                                    </td>
+                                    <td>
+                                        <span th:if="${desig.minSalary != null or desig.maxSalary != null}"
+                                            class="salary-range">
+                                            ₹<span
+                                                th:text="${#numbers.formatDecimal(desig.minSalary ?: 0, 1, 'COMMA', 0, 'POINT')}">0</span>
+                                            &ndash;
+                                            ₹<span
+                                                th:text="${#numbers.formatDecimal(desig.maxSalary ?: 0, 1, 'COMMA', 0, 'POINT')}">0</span>
+                                        </span>
+                                        <span th:unless="${desig.minSalary != null or desig.maxSalary != null}"
+                                            class="text-muted">—</span>
+                                    </td>
+                                    <td>
+                                        <span class="badge bg-info" th:text="${desig.employeeCount + ' member(s)'}">0
+                                            member(s)</span>
+                                    </td>
+                                    <td>
+                                        <span th:if="${desig.isActive == 'Y'}" class="badge-active">
+                                            <i class="fas fa-circle"
+                                                style="font-size:0.5rem; margin-right:3px;"></i>Active
+                                        </span>
+                                        <span th:unless="${desig.isActive == 'Y'}" class="badge-inactive">
+                                            <i class="fas fa-circle"
+                                                style="font-size:0.5rem; margin-right:3px;"></i>Inactive
+                                        </span>
+                                    </td>
+                                    <td style="display:flex; gap:0.4rem; flex-wrap:wrap;">
+                                        <a th:href="@{/admin/designations/edit/{id}(id=${desig.designationId})}"
+                                            class="btn btn-secondary btn-sm">
+                                            <i class="fas fa-edit"></i> Edit
+                                        </a>
+                                        <form th:action="@{/admin/designations/delete/{id}(id=${desig.designationId})}"
+                                            method="POST" style="display:inline;"
+                                            onsubmit="return confirm('Delete designation \'' + this.dataset.name + '\'? This action cannot be undone.');"
+                                            th:data-name="${desig.designationName}">
+                                            <button type="submit" class="btn btn-danger btn-sm">
+                                                <i class="fas fa-trash"></i> Delete
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                                <tr th:if="${#lists.isEmpty(designations)}">
+                                    <td colspan="7" class="text-center text-muted" style="padding:3rem;">
+                                        <i class="fas fa-id-badge"
+                                            style="font-size:2rem; opacity:0.3; display:block; margin-bottom:0.75rem;"></i>
+                                        No designations found. <a th:href="@{/admin/designations/add}">Add the first
+                                            one.</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
+        </main>
+    </div>
+    <script th:src="@{/js/components.js}"></script>
+    <script th:src="@{/js/app.js}"></script>
+</body>
+
+</html>

--- a/src/main/resources/templates/frontend/pages/admin/employee-form.html
+++ b/src/main/resources/templates/frontend/pages/admin/employee-form.html
@@ -65,6 +65,37 @@
             border-color: #e53935;
         }
 
+        /* Alert banners for success/error messages */
+        .alert-banner {
+            padding: 0.85rem 1.1rem;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            font-size: 0.92rem;
+            font-weight: 500;
+        }
+
+        .alert-banner.success {
+            background: #d4edda;
+            color: #155724;
+            border-left: 4px solid #28a745;
+        }
+
+        .alert-banner.error {
+            background: #f8d7da;
+            color: #721c24;
+            border-left: 4px solid #dc3545;
+        }
+
+        .text-danger {
+            font-size: 0.78rem;
+            color: #e53935;
+            margin-top: 0.25rem;
+            display: block;
+        }
+
         @media (max-width: 768px) {
 
             .field-grid-3,
@@ -120,18 +151,41 @@
                             <!-- Role Selection (drives EmpID prefix) -->
                             <div class="form-group">
                                 <label class="form-label">Role <span class="required">*</span></label>
-                                <select id="roleSelect" name="roleIds" class="form-control" required
-                                    th:disabled="${isEdit}">
-                                    <option value="">— Select Role —</option>
-                                    <option th:each="r : ${roles}" th:value="${r.roleId}" th:text="${r.roleName}"
-                                        th:attr="data-prefix=${
-                                                #strings.containsIgnoreCase(r.roleName,'ADMIN')   ? 'ADM' :
-                                                #strings.containsIgnoreCase(r.roleName,'MANAGER') ? 'MGR' : 'EMP'
-                                            }"
-                                        th:selected="${employeeDTO.roleIds != null and !employeeDTO.roleIds.isEmpty() and employeeDTO.roleIds.contains(r.roleId)}">
-                                    </option>
-                                </select>
-                                <div class="field-hint">Employee ID prefix is auto-generated from this selection</div>
+                                <!--
+                                    NOTE: We use "th:disabled" only for UX (greyed-out look) but we
+                                    must NOT use disabled on the select itself in edit mode because
+                                    disabled fields are NOT submitted by browsers.
+                                    Instead we render the select without th:disabled and use JS to
+                                    visually lock it, while hidden inputs carry the values.
+                                -->
+                                <!-- ADD mode: interactive role select -->
+                                <div th:if="${!isEdit}">
+                                    <select id="roleSelect" name="roleIds" class="form-control" required>
+                                        <option value="">— Select Role —</option>
+                                        <option th:each="r : ${roles}" th:value="${r.roleId}" th:text="${r.roleName}"
+                                            th:attr="data-prefix=${
+                                                    #strings.containsIgnoreCase(r.roleName,'ADMIN')   ? 'ADM' :
+                                                    #strings.containsIgnoreCase(r.roleName,'MANAGER') ? 'MGR' : 'EMP'
+                                                }"
+                                            th:selected="${employeeDTO.roleIds != null and !employeeDTO.roleIds.isEmpty() and employeeDTO.roleIds.contains(r.roleId)}">
+                                        </option>
+                                    </select>
+                                    <div class="field-hint">Employee ID prefix is auto-generated from this selection
+                                    </div>
+                                </div>
+                                <!-- EDIT mode: locked role display + hidden inputs to actually submit the values -->
+                                <div th:if="${isEdit}">
+                                    <select id="roleSelect" class="form-control"
+                                        style="pointer-events:none; opacity:0.7; background:#f5f5f5;" disabled>
+                                        <option th:each="r : ${roles}" th:value="${r.roleId}" th:text="${r.roleName}"
+                                            th:selected="${employeeDTO.roleIds != null and employeeDTO.roleIds.contains(r.roleId)}">
+                                        </option>
+                                    </select>
+                                    <!-- Hidden inputs so roleIds are actually submitted in edit mode -->
+                                    <input th:each="rid : ${employeeDTO.roleIds}" type="hidden" name="roleIds"
+                                        th:value="${rid}" />
+                                    <div class="field-hint">Role cannot be changed here — use Role Management.</div>
+                                </div>
                             </div>
 
                             <!-- Employee ID (auto-generated) -->
@@ -268,11 +322,11 @@
                                 <label class="form-label">Reporting Manager</label>
                                 <select class="form-control" th:field="*{managerId}">
                                     <option value="">No Manager</option>
-                                    <!-- Only manager-role employees are passed in this list -->
+                                    <!-- Includes active MANAGER and ADMIN employees -->
                                     <option th:each="mgr : ${managers}" th:value="${mgr.employeeId}"
                                         th:text="${mgr.fullName + ' (' + mgr.employeeId + ')'}"></option>
                                 </select>
-                                <div class="field-hint">Only active managers are listed</div>
+                                <div class="field-hint">Lists active Managers and Admins</div>
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Joining Date <span class="required">*</span></label>


### PR DESCRIPTION
feat: Add Department/Designation CRUD UI & fix Employee form bugs

- Add 4 Thymeleaf templates for Department and Designation CRUD:
  - admin/departments/list.html — table with status badges, edit/delete actions
  - admin/departments/form.html — add/edit form with char counter
  - admin/designations/list.html — table with salary range, level badge
  - admin/designations/form.html — add/edit form with live salary preview

- Fix: Add Employee not persisting due to invisible validation errors
  - Add missing alert-banner CSS to employee-form.html
  - Fix roleIds disabled select not submitting in edit mode
    (use hidden inputs to carry values when select is locked)
  - Improve error handling with null-safe fallback messages
  - Display readable validation error summary on form resubmit

- Fix: Reporting Manager dropdown missing Admin employees
  - Add findActiveEmployeesByRoleNames() query to EmployeeRepository
  - Update EmployeeController to include both MANAGER and ADMIN
    in the Reporting Manager dropdown across all 4 handler methods
