### PR TITLE
Fix HolidayType enum mismatch issue

### DIFF
--- a/src/main/resources/templates/frontend/pages/admin/holidays/form.html
+++ b/src/main/resources/templates/frontend/pages/admin/holidays/form.html
@@ -40,10 +40,14 @@
 <select th:field="*{type}" class="form-control">
 
 <option value="">Select Type</option>
+
 <option value="NATIONAL">National Holiday</option>
+
 <option value="REGIONAL">Regional Holiday</option>
+
 <option value="FESTIVAL">Festival</option>
-<option value="COMPANY">Company Holiday</option>
+
+<option value="COMPANY_SPECIFIC">Company Holiday</option>
 
 </select>
 


### PR DESCRIPTION
@MastanSayyad 

Resolved an issue where the HolidayType value from the form did not match the enum values defined in the backend.
Updated the holiday form dropdown to use the correct enum value `COMPANY_SPECIFIC` instead of `COMPANY`, ensuring proper binding between the UI and the HolidayType enum.
This fix prevents the validation error that occurred while creating or updating holidays.