### PR TITLE
Fix leave balance display and resolve notification mark-all-read issue

### DIFF
--- a/src/main/resources/templates/frontend/fragments/notification-bell.html
+++ b/src/main/resources/templates/frontend/fragments/notification-bell.html
@@ -25,12 +25,18 @@
     <strong>Notifications</strong>
 
     <div>
-        <form th:action="@{/notifications/mark-all-read}" method="post" style="display:inline;">
-            <button type="submit"
-                    class="btn btn-link btn-sm p-0 me-2">
-                Mark all as read
-            </button>
-        </form>
+       <form th:action="@{/notifications/mark-all-read}" method="post" style="display:inline;">
+
+    <input type="hidden"
+           th:name="${_csrf.parameterName}"
+           th:value="${_csrf.token}" />
+
+    <button type="submit"
+            class="btn btn-link btn-sm p-0 me-2">
+        Mark all as read
+    </button>
+
+</form>
 
         <a href="/notifications" class="ms-2">View All Activity</a> 
     </div>

--- a/src/main/resources/templates/frontend/pages/manager/leave-approvals.html
+++ b/src/main/resources/templates/frontend/pages/manager/leave-approvals.html
@@ -50,7 +50,7 @@
 					<div class="tabs">
 						<button class="tab-btn" data-target="pending-requests">Pending
 							Requests</button>
-						<button class="tab-btn" data-target="approved-revokes">Approved/Revoke</button>
+						<button class="tab-btn" data-target="approved-revokes">Approved/Rejected</button>
 						<button class="tab-btn" data-target="team-calendar">Team
 							Calendar</button>
 					</div>
@@ -270,7 +270,7 @@ onsubmit="let reason = prompt('Please enter a rejection reason:');
 
 												<td><th:block th:each="b : ${teamBalances}">
 														<span
-															th:if="${b.employee.employeeId == member.employeeId and b.leaveType.leaveCode == 'PreL'}"
+															th:if="${b.employee.employeeId == member.employeeId and b.leaveType.leaveCode == 'PRIV'}"
 															th:text="${b.balance}" th:remove="tag"> </span>
 													</th:block></td>
 

--- a/src/main/resources/templates/frontend/pages/notifications/list.html
+++ b/src/main/resources/templates/frontend/pages/notifications/list.html
@@ -10,14 +10,23 @@
     <div class="container mt-4">
 
         <div class="d-flex justify-content-between align-items-center mb-4">
-            <h3><i class="fas fa-bell me-2"></i>All Notifications</h3>
-            <form th:if="${not #lists.isEmpty(notifications)}" th:action="@{/notifications/mark-all-read}"
-                method="post">
-                <button type="submit" class="btn btn-outline-primary btn-sm">
-                    <i class="fas fa-check-double me-1"></i>Mark All as Read
-                </button>
-            </form>
-        </div>
+    <h3><i class="fas fa-bell me-2"></i>All Notifications</h3>
+
+    <form th:if="${not #lists.isEmpty(notifications)}"
+          th:action="@{/notifications/mark-all-read}"
+          method="post">
+
+        <!-- CSRF token -->
+        <input type="hidden"
+               th:name="${_csrf.parameterName}"
+               th:value="${_csrf.token}" />
+
+        <button type="submit" class="btn btn-outline-primary btn-sm">
+            <i class="fas fa-check-double me-1"></i>Mark All as Read
+        </button>
+
+    </form>
+</div>
 
         <div class="card shadow-sm">
             <div class="card-body">


### PR DESCRIPTION
@MastanSayyad 
This PR resolves multiple issues in the Leave Management and Notifications modules.

Changes implemented:

1. Fixed Privilege Leave balance not displaying in the team leave balance table by correcting the leave code mapping to match the database value (PRIV).

2. Resolved the "Mark All as Read" notification action not working for Employee users by adding the required CSRF token to notification forms.

3. Updated notification forms in both the notifications list page and notification bell dropdown to ensure secure POST requests compliant with Spring Security CSRF protection.

These changes ensure:
- Leave balances display correctly for all leave types.
- Notification actions function properly for Employee, Manager, and Admin roles.
- Forms comply with Spring Security security requirements.